### PR TITLE
chore: upgrade to crystal 1.9.2

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ targets:
   specbox-api:
     main: src/specbox-api.cr
 
-crystal: 1.8.2
+crystal: 1.9.2
 
 license: MIT


### PR DESCRIPTION
Crystalのバージョンを1.9.2に上げます